### PR TITLE
scrapers: parallelize via GHA matrix + bound Haiku call time

### DIFF
--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -5,10 +5,29 @@ on:
     - cron: '0 11 * * *'
   workflow_dispatch:
 
+concurrency:
+  group: scrape-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   scrape:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 25
+    strategy:
+      fail-fast: false
+      max-parallel: 6
+      matrix:
+        source:
+          - aljazeera
+          - bbc
+          - borderlandbeat
+          - courthousenews
+          - democracynow
+          - dropsitenews
+          - intercept
+          - jacobin
+          - npr
+    name: scrape-${{ matrix.source }}
     steps:
       - uses: actions/checkout@v4
 
@@ -21,10 +40,10 @@ jobs:
 
       - run: npx playwright install --with-deps chromium
 
-      - name: Run all scrapers
+      - name: Run scraper (${{ matrix.source }})
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           INGEST_URL: ${{ secrets.INGEST_URL }}
           INGEST_SECRET: ${{ secrets.INGEST_SECRET }}
           SCRAPE_LIMIT: '15'
-        run: npm run scraper:all
+        run: npm run scraper:${{ matrix.source }}

--- a/scrapers/lib/haiku.ts
+++ b/scrapers/lib/haiku.ts
@@ -44,15 +44,24 @@ const EXTRACT_TOOL = {
   },
 }
 
+const REQUEST_TIMEOUT_MS = 75_000
+const REQUEST_MAX_RETRIES = 1
+
 export async function extractArticle(pageText: string): Promise<ExtractedArticle> {
-  const res = await client.messages.create({
-    model: MODEL,
-    max_tokens: 4096,
-    system: SYSTEM_PROMPT,
-    tools: [EXTRACT_TOOL],
-    tool_choice: { type: 'tool', name: 'extract_article' },
-    messages: [{ role: 'user', content: pageText.slice(0, 200_000) }],
-  })
+  const res = await client.messages.create(
+    {
+      model: MODEL,
+      max_tokens: 4096,
+      system: SYSTEM_PROMPT,
+      tools: [EXTRACT_TOOL],
+      tool_choice: { type: 'tool', name: 'extract_article' },
+      messages: [{ role: 'user', content: pageText.slice(0, 200_000) }],
+    },
+    {
+      timeout: REQUEST_TIMEOUT_MS,
+      maxRetries: REQUEST_MAX_RETRIES,
+    },
+  )
 
   const toolUse = res.content.find(block => block.type === 'tool_use')
   if (!toolUse || toolUse.type !== 'tool_use') {
@@ -60,13 +69,22 @@ export async function extractArticle(pageText: string): Promise<ExtractedArticle
   }
 
   const input = toolUse.input as Partial<ExtractedArticle>
+  const headline = (input.headline ?? '').trim()
+  const body = (input.body ?? '').trim()
+  const date = (input.date ?? '').trim()
+
+  if (!headline || !body || !date) {
+    throw new Error(
+      `Haiku returned incomplete article (headline=${!!headline}, body=${!!body}, date=${!!date})`,
+    )
+  }
 
   return {
-    headline: input.headline ?? '',
-    summary: input.summary ?? '',
-    body: input.body ?? '',
-    location: input.location ?? '',
-    media: input.media ?? '',
-    date: input.date ?? new Date().toISOString(),
+    headline,
+    summary: (input.summary ?? '').trim(),
+    body,
+    location: (input.location ?? '').trim(),
+    media: (input.media ?? '').trim(),
+    date,
   }
 }


### PR DESCRIPTION
  - split scrape.yml into a matrix job (one runner per source) with fail-fast: false and max-parallel: 6, so a slow/hung source can't starve the others
  - per-request timeout (75s) and maxRetries (1) on Anthropic messages.create, replacing the SDK's 10-min default
  - extractArticle now throws on empty headline/body/date so incomplete Haiku responses fail fast instead of producing 422s at the ingest endpoint
  - concurrency group on the workflow prevents a manual dispatch from racing the scheduled run