### PR TITLE
scrapers: 3x daily cron + v6 action bumps + date-first ordering

### DIFF
--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -2,7 +2,9 @@ name: Daily scrape
 
 on:
   schedule:
-    - cron: '0 11 * * *'
+    - cron: '0 11 * * *'   # 07:00 EDT / 06:00 EST — morning
+    - cron: '0 15 * * *'   # 11:00 EDT / 10:00 EST — late morning (catches sources that post after 10 UTC)
+    - cron: '0 21 * * *'   # 17:00 EDT / 16:00 EST — afternoon refresh
   workflow_dispatch:
 
 concurrency:
@@ -29,9 +31,9 @@ jobs:
           - npr
     name: scrape-${{ matrix.source }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'npm'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,7 +133,7 @@ TL;DR:
 
 - Lives in `scrapers/` (excluded from the Next build via `tsconfig.json`)
 - Run locally: `npm run scraper:<source>` or `npm run scraper:all`
-- Runs on GitHub Actions cron daily at 11:00 UTC (07:00 EDT / 06:00 EST)
+- Runs on GitHub Actions cron 3x daily at 11:00, 15:00, 21:00 UTC (07:00 / 11:00 / 17:00 EDT)
 - Env vars: `ANTHROPIC_API_KEY`, `INGEST_URL`, `INGEST_SECRET`, optional `SCRAPE_LIMIT` (default 15, `0` = unlimited)
 - Clear: `npm run db:clear -- <source-name>` or `-- --all`
 - Haiku uses **tool-use mode** (`extract_article` tool) for strict-typed JSON output — no regex/JSON.parse brittleness

--- a/SCRAPERS.md
+++ b/SCRAPERS.md
@@ -5,16 +5,17 @@ Daily news scrapers for RealWorldNewsApp. Each scraper pulls article URLs from a
 ## Architecture
 
 ```
-GitHub Actions cron (11:00 UTC daily)
-  └─ npm run scraper:all
-       └─ ts-node scrapers/sources/<source>.ts (per source)
-            ├─ Playwright fetches listing + article HTML
-            ├─ Claude Haiku extracts { headline, summary, body, location, media, source, sourceUrl, date }
-            ├─ Collect all payloads in memory
-            ├─ DELETE /api/articles?source=<name>   (clears only this source, only after scrape succeeded)
-            └─ POST /api/articles per payload (Bearer INGEST_SECRET)
-                 └─ prisma.article.upsert  (slug-based dedup)
-                    + revalidatePath('/') and revalidatePath('/articles/<slug>')
+GitHub Actions cron (3x daily: 11:00, 15:00, 21:00 UTC)
+  └─ matrix: one runner per source, running in parallel (fail-fast: false, max-parallel: 6)
+       └─ npm run scraper:<source>
+            └─ ts-node scrapers/sources/<source>.ts
+                 ├─ Playwright fetches listing + article HTML
+                 ├─ Claude Haiku extracts { headline, summary, body, location, media, source, sourceUrl, date }
+                 ├─ Collect all payloads in memory
+                 ├─ DELETE /api/articles?source=<name>   (clears only this source, only after scrape succeeded)
+                 └─ POST /api/articles per payload (Bearer INGEST_SECRET)
+                      └─ prisma.article.upsert  (slug-based dedup)
+                         + revalidatePath('/') and revalidatePath('/articles/<slug>')
 ```
 
 ### Refresh strategy
@@ -142,12 +143,35 @@ The scraper reads `INGEST_URL` from `.env.local`. Point it at `http://localhost:
 
 **Manually against prod:** flip `INGEST_URL` in `.env.local` to your production URL, then run the same command. Be careful — writes go straight to the prod DB.
 
-**Scheduled (prod):** GitHub Actions runs `npm run scraper:all` every day at 11:00 UTC (07:00 EDT / 06:00 EST). Trigger an immediate run from the Actions tab → "Daily scrape" → "Run workflow".
+**Scheduled (prod):** GitHub Actions runs the matrix workflow three times daily — 11:00, 15:00, and 21:00 UTC (07:00 / 11:00 / 17:00 EDT). Each source fans out to its own runner and its own 25-min budget, so one slow source can't starve the others. The late-morning run exists because sources like Democracy Now! and Drop Site News don't post until ~13:00 UTC, so an 11 UTC run would miss them by hours.
 
 GitHub secrets required:
 - `ANTHROPIC_API_KEY`
 - `INGEST_URL` (production URL)
 - `INGEST_SECRET`
+
+**Trigger an immediate run:**
+
+From the web UI — Actions tab → "Daily scrape" → "Run workflow".
+
+From the terminal, using [GitHub CLI](https://cli.github.com/):
+
+```
+# one-time setup
+brew install gh
+gh auth login                   # GitHub.com → pick protocol → browser login
+gh repo set-default             # pick the RealWorldNewsApp remote
+
+# dispatch + live-tail
+gh workflow run scrape.yml
+gh run watch                    # pick the newest run from the list
+```
+
+Ctrl-C out of `gh run watch` anytime — the run keeps going on GitHub. To list past runs: `gh run list --workflow=scrape.yml`.
+
+### Per-call Haiku bounds
+
+Each Haiku extraction is capped at `timeout: 75_000` ms with `maxRetries: 1` (see `scrapers/lib/haiku.ts`). A single stalled API call bails in ≤150s instead of inheriting the SDK's 10-minute default, so one bad article can't eat a source's whole budget. `extractArticle` also throws if Haiku returns empty `headline`/`body`/`date`, so incomplete responses fail fast at the boundary instead of producing 422s at the ingest endpoint.
 
 ## Clearing data
 

--- a/lib/articles.tsx
+++ b/lib/articles.tsx
@@ -49,7 +49,7 @@ export async function getArticles(
     ? searchScoped.filter((a) => a.source === source)
     : searchScoped;
 
-  const staggered = source ? filtered : interleaveBySource(filtered);
+  const staggered = source ? filtered : interleaveByDayAndSource(filtered);
   const start = (page - 1) * pageSize;
   const articles = staggered.slice(start, start + pageSize);
 
@@ -61,7 +61,12 @@ export async function getArticles(
   };
 }
 
-function interleaveBySource(articles: Article[]): Article[] {
+function dayKey(date: Date | string): string {
+  const d = typeof date === "string" ? new Date(date) : date;
+  return d.toISOString().slice(0, 10);
+}
+
+function roundRobinBySource(articles: Article[]): Article[] {
   const queues = new Map<string, Article[]>();
   for (const a of articles) {
     const key = a.source || "unknown";
@@ -80,6 +85,22 @@ function interleaveBySource(articles: Article[]): Article[] {
         remaining--;
       }
     }
+  }
+  return out;
+}
+
+function interleaveByDayAndSource(articles: Article[]): Article[] {
+  const byDay = new Map<string, Article[]>();
+  for (const a of articles) {
+    const key = dayKey(a.date);
+    if (!byDay.has(key)) byDay.set(key, []);
+    byDay.get(key)!.push(a);
+  }
+
+  const days = Array.from(byDay.keys()).sort().reverse();
+  const out: Article[] = [];
+  for (const day of days) {
+    out.push(...roundRobinBySource(byDay.get(day)!));
   }
   return out;
 }


### PR DESCRIPTION
  - schedule fires at 11/15/21 UTC (07/11/17 EDT) so late-morning sources like Democracy Now! and Drop Site News land in the feed same-day instead of waiting until tomorrow
  - bump actions/checkout and actions/setup-node to v6 — kills the Node 20 deprecation warning ahead of the June 2026 forced-upgrade
  - homepage feed now sorts by calendar day (UTC) first, then round-robins by source within the day — April 20 articles land above April 19, without losing source-diversity shuffle
  - SCRAPERS.md and CLAUDE.md updated to match the new schedule