### PR TITLE
scrapers: fix drop site future-date bug + author in search + future-d…

### DIFF
--- a/app/api/articles/route.ts
+++ b/app/api/articles/route.ts
@@ -40,6 +40,11 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ message: 'Invalid date' }, { status: 422 })
   }
 
+  const oneDayMs = 24 * 60 * 60 * 1000
+  if (parsedDate.getTime() > Date.now() + oneDayMs) {
+    return NextResponse.json({ message: 'Date is in the future' }, { status: 422 })
+  }
+
   const data = {
     slug: slug.trim(),
     headline: headline.trim(),

--- a/lib/articles.tsx
+++ b/lib/articles.tsx
@@ -27,6 +27,7 @@ export async function getArticles(
           { summary: { contains: searchQuery, mode: "insensitive" as const } },
           { location: { contains: searchQuery, mode: "insensitive" as const } },
           { source: { contains: searchQuery, mode: "insensitive" as const } },
+          { author: { contains: searchQuery, mode: "insensitive" as const } },
         ],
       }
     : {};

--- a/scrapers/sources/dropsitenews.ts
+++ b/scrapers/sources/dropsitenews.ts
@@ -97,21 +97,12 @@ function toISO(input: string): string {
 function extractPublishedTime($doc: cheerio.CheerioAPI): string {
   const metaTime = $doc('meta[property="article:published_time"]').attr('content')
   if (metaTime) return metaTime
-  const timeAttr = $doc('time[datetime]').first().attr('datetime')
-  if (timeAttr) return timeAttr
-  // Substack byline: plain text like "Apr 17, 2026". Search for any element whose
-  // text parses as a date.
-  let found = ''
-  $doc('.post-header div, .byline-wrapper div, [class*="meta"]').each((_, el) => {
-    if (found) return
-    const text = $doc(el).text().trim()
-    if (!text || text.length > 30) return
-    const parsed = new Date(text)
-    if (!isNaN(parsed.getTime()) && parsed.getFullYear() > 2000) {
-      found = parsed.toISOString()
-    }
-  })
-  return found
+  // Scope the <time> fallback to the article header so we don't pick up
+  // timestamps from related-post rails. No plain-text fallback: V8's Date
+  // parser is permissive enough that a byline like "Julian Andreone" can
+  // parse as "Jul" + numbers nearby and produce a July date.
+  const scopedTime = $doc('.post-header time[datetime], .byline-wrapper time[datetime]').first().attr('datetime')
+  return scopedTime ?? ''
 }
 
 function buildMinimalDoc(html: string, videoUrl: string): string {


### PR DESCRIPTION
…ate guard

  - drop site's extractPublishedTime had a plain-text fallback that ran every [class*="meta"] element through `new Date()`. Substack bylines with "Julian Andreone" parse as "Jul 17" in V8's lenient date parser, which is why the Angie Craig piece landed as July 17, 2026 instead of April 17. Fallback removed — only the meta tag and a header-scoped <time> element are trusted now
  - ingest endpoint now rejects dates more than 24h in the future with a 422, as a global safety net against this class of bug from any scraper
  - author added to the homepage search OR so filtering by "julian" or any byline actually returns results