### PR TITLE
ux: whole-card clickable via card-link pattern

### DIFF
--- a/components/articles/article-item.module.css
+++ b/components/articles/article-item.module.css
@@ -1,4 +1,5 @@
 .article {
+  position: relative;
   display: grid;
   grid-template-rows: auto 1fr auto;
   gap: var(--size-3);
@@ -11,14 +12,16 @@
   transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
 }
 
-.article:hover {
+.article:hover,
+.article:focus-within {
   transform: translateY(-2px);
   box-shadow: 0 6px 20px rgba(0, 0, 0, 0.25);
   border-color: rgba(var(--muted-text-rgb), 0.2);
 }
 
-.imageLink {
-  display: block;
+.article:focus-within {
+  outline: 2px solid var(--link);
+  outline-offset: 2px;
 }
 
 .image {
@@ -43,6 +46,7 @@
   text-transform: uppercase;
   border-radius: 4px;
   pointer-events: none;
+  z-index: 1;
 }
 
 .article img {
@@ -57,7 +61,7 @@
   padding-block-start: var(--size-2);
 }
 
-.header h2 {
+.title {
   margin: 0;
   font-size: 1.125rem;
   font-family: 'Montserrat', sans-serif;
@@ -66,11 +70,20 @@
   color: var(--foreground);
 }
 
-.header a {
+.titleLink {
   color: inherit;
+  text-decoration: none;
+  outline: none;
 }
 
-.header h2:hover {
+.titleLink::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+}
+
+.article:hover .title {
   opacity: 70%;
 }
 
@@ -101,11 +114,6 @@
 .actions {
   padding-inline: var(--size-4);
   text-align: end;
-}
-
-.actions a {
-  display: inline-block;
-  padding-block: var(--size-1);
   font-size: 0.8rem;
   font-weight: 700;
   letter-spacing: 0.05rem;
@@ -113,13 +121,12 @@
   text-transform: uppercase;
 }
 
-.actions a:hover,
-.actions a:active {
+.article:hover .actions {
   opacity: 70%;
 }
 
 @media (min-width: 768px) {
-  .header h2 {
+  .title {
     font-size: 1.25rem;
   }
   .summary {

--- a/components/articles/article-item.tsx
+++ b/components/articles/article-item.tsx
@@ -22,25 +22,25 @@ export default function ArticleItem({
   return (
     <li>
       <article className={classes.article}>
-        <Link href={`/articles/${slug}`} className={classes.imageLink}>
-          <div className={classes.image}>
-            {media && (
-              <Image
-                src={media}
-                alt={slug}
-                fill
-                sizes="(max-width: 768px) 100vw, (max-width: 1024px) 50vw, 33vw"
-              />
-            )}
-            {videoUrl && (
-              <span className={classes.videoBadge} aria-label="Video">▶ Video</span>
-            )}
-          </div>
-        </Link>
+        <div className={classes.image}>
+          {media && (
+            <Image
+              src={media}
+              alt={slug}
+              fill
+              sizes="(max-width: 768px) 100vw, (max-width: 1024px) 50vw, 33vw"
+            />
+          )}
+          {videoUrl && (
+            <span className={classes.videoBadge} aria-label="Video">▶ Video</span>
+          )}
+        </div>
         <header className={classes.header}>
-          <Link href={`/articles/${slug}`}>
-            <h2>{headline}</h2>
-          </Link>
+          <h2 className={classes.title}>
+            <Link href={`/articles/${slug}`} className={classes.titleLink}>
+              {headline}
+            </Link>
+          </h2>
           <div className={classes.meta}>
             {author && <span>By {author}</span>}
             {location && <span>{location}</span>}
@@ -48,8 +48,8 @@ export default function ArticleItem({
           </div>
         </header>
         {summary && <p className={classes.summary}>{summary}</p>}
-        <div className={classes.actions}>
-          <Link href={`/articles/${slug}`}>View Details →</Link>
+        <div className={classes.actions} aria-hidden="true">
+          View Details →
         </div>
       </article>
     </li>


### PR DESCRIPTION
  - card is now a single semantic link on the headline with an ::after pseudo-element filling the card, so clicking anywhere on it navigates to the article. cmd-click, middle-click, right-click, and status-bar URL preview all work as native link behavior
  - dropped from three <Link> elements per card (image, headline, View Details) to one — eliminates redundant anchors that screen readers were announcing three times
  - "View Details →" kept as an aria-hidden visual affordance so it still signals interactivity without adding a second link
  - :focus-within on the article shows the whole card lighting up when Tab-focused, instead of an invisible outline on the hidden headline link
  - video badge sits above the ::after overlay via z-index, with pointer-events: none so clicks through it still navigate