### PR TITLE
ux: whole-card clickable by wrapping card in a single <Link>

### DIFF
--- a/components/articles/article-item.module.css
+++ b/components/articles/article-item.module.css
@@ -1,5 +1,11 @@
+.card {
+  display: block;
+  block-size: 100%;
+  color: inherit;
+  text-decoration: none;
+}
+
 .article {
-  position: relative;
   display: grid;
   grid-template-rows: auto 1fr auto;
   gap: var(--size-3);
@@ -12,16 +18,21 @@
   transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
 }
 
-.article:hover,
-.article:focus-within {
+.card:hover .article,
+.card:focus-visible .article {
   transform: translateY(-2px);
   box-shadow: 0 6px 20px rgba(0, 0, 0, 0.25);
   border-color: rgba(var(--muted-text-rgb), 0.2);
 }
 
-.article:focus-within {
+.card:focus-visible {
   outline: 2px solid var(--link);
   outline-offset: 2px;
+  border-radius: 12px;
+}
+
+.card:focus {
+  outline: none;
 }
 
 .image {
@@ -46,7 +57,6 @@
   text-transform: uppercase;
   border-radius: 4px;
   pointer-events: none;
-  z-index: 1;
 }
 
 .article img {
@@ -70,20 +80,7 @@
   color: var(--foreground);
 }
 
-.titleLink {
-  color: inherit;
-  text-decoration: none;
-  outline: none;
-}
-
-.titleLink::after {
-  content: "";
-  position: absolute;
-  inset: 0;
-  border-radius: inherit;
-}
-
-.article:hover .title {
+.card:hover .title {
   opacity: 70%;
 }
 
@@ -121,7 +118,7 @@
   text-transform: uppercase;
 }
 
-.article:hover .actions {
+.card:hover .actions {
   opacity: 70%;
 }
 

--- a/components/articles/article-item.tsx
+++ b/components/articles/article-item.tsx
@@ -21,37 +21,35 @@ export default function ArticleItem({
   });
   return (
     <li>
-      <article className={classes.article}>
-        <div className={classes.image}>
-          {media && (
-            <Image
-              src={media}
-              alt={slug}
-              fill
-              sizes="(max-width: 768px) 100vw, (max-width: 1024px) 50vw, 33vw"
-            />
-          )}
-          {videoUrl && (
-            <span className={classes.videoBadge} aria-label="Video">▶ Video</span>
-          )}
-        </div>
-        <header className={classes.header}>
-          <h2 className={classes.title}>
-            <Link href={`/articles/${slug}`} className={classes.titleLink}>
-              {headline}
-            </Link>
-          </h2>
-          <div className={classes.meta}>
-            {author && <span>By {author}</span>}
-            {location && <span>{location}</span>}
-            <span>{humanReadableDate}</span>
+      <Link href={`/articles/${slug}`} className={classes.card}>
+        <article className={classes.article}>
+          <div className={classes.image}>
+            {media && (
+              <Image
+                src={media}
+                alt={slug}
+                fill
+                sizes="(max-width: 768px) 100vw, (max-width: 1024px) 50vw, 33vw"
+              />
+            )}
+            {videoUrl && (
+              <span className={classes.videoBadge} aria-label="Video">▶ Video</span>
+            )}
           </div>
-        </header>
-        {summary && <p className={classes.summary}>{summary}</p>}
-        <div className={classes.actions} aria-hidden="true">
-          View Details →
-        </div>
-      </article>
+          <header className={classes.header}>
+            <h2 className={classes.title}>{headline}</h2>
+            <div className={classes.meta}>
+              {author && <span>By {author}</span>}
+              {location && <span>{location}</span>}
+              <span>{humanReadableDate}</span>
+            </div>
+          </header>
+          {summary && <p className={classes.summary}>{summary}</p>}
+          <div className={classes.actions} aria-hidden="true">
+            View Details →
+          </div>
+        </article>
+      </Link>
     </li>
   );
 }

--- a/scrapers/sources/courthousenews.ts
+++ b/scrapers/sources/courthousenews.ts
@@ -33,7 +33,9 @@ async function dismissPopup(page: Awaited<ReturnType<Browser['newPage']>>) {
   }
 }
 
-async function getArticleLinks(browser: Browser): Promise<string[]> {
+type Candidate = { url: string; author: string }
+
+async function getArticleLinks(browser: Browser): Promise<Candidate[]> {
   const page = await browser.newPage({
     userAgent:
       'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36',
@@ -42,23 +44,32 @@ async function getArticleLinks(browser: Browser): Promise<string[]> {
     await page.goto(INDEX_URL, { waitUntil: 'domcontentloaded', timeout: 30_000 })
     await dismissPopup(page)
 
-    const hrefs = await page.$$eval(
-      '.arpr_article_preview h2 a, .arpr_article_preview .image a',
-      els => els.map(el => (el as HTMLAnchorElement).getAttribute('href') ?? ''),
-    )
+    const html = await page.content()
+    const $ = cheerio.load(html)
 
     const seen = new Set<string>()
-    const allMatches: string[] = []
-    for (const href of hrefs) {
-      if (!href) continue
+    const candidates: Candidate[] = []
+    let totalCards = 0
+    $('.arpr_article_preview').each((_, card) => {
+      totalCards += 1
+      const $card = $(card)
+      const href = $card.find('h2 a').first().attr('href') ?? $card.find('.image a').first().attr('href') ?? ''
+      if (!href) return
       const full = href.startsWith('http') ? href : `${BASE_URL}${href}`
-      if (!STORY_PATH.test(full)) continue
-      if (seen.has(full)) continue
+      if (!STORY_PATH.test(full)) return
+      if (seen.has(full)) return
       seen.add(full)
-      allMatches.push(full)
-    }
-    log(SOURCE, 'candidates', { totalOnPage: hrefs.length, matchingStoryUrls: allMatches.length })
-    return env.SCRAPE_LIMIT > 0 ? allMatches.slice(0, env.SCRAPE_LIMIT) : allMatches
+
+      const authorNames: string[] = []
+      $card.find('p.author a, .author a, .entry-byline a').each((_, a) => {
+        const name = $(a).text().trim()
+        if (name && !authorNames.includes(name)) authorNames.push(name)
+      })
+      candidates.push({ url: full, author: authorNames.join(', ') })
+    })
+
+    log(SOURCE, 'candidates', { totalCards, matchingStoryUrls: candidates.length })
+    return env.SCRAPE_LIMIT > 0 ? candidates.slice(0, env.SCRAPE_LIMIT) : candidates
   } finally {
     await page.close()
   }
@@ -109,23 +120,23 @@ async function run() {
   const browser = await chromium.launch({ headless: true })
   const payloads: ArticlePayload[] = []
   try {
-    const urls = await getArticleLinks(browser)
-    log(SOURCE, 'found-links', { count: urls.length })
+    const candidates = await getArticleLinks(browser)
+    log(SOURCE, 'found-links', { count: candidates.length })
 
-    for (let i = 0; i < urls.length; i++) {
-      const url = urls[i]
+    for (let i = 0; i < candidates.length; i++) {
+      const { url, author: listingAuthor } = candidates[i]
       const t0 = Date.now()
-      log(SOURCE, 'extract-start', { index: i + 1, of: urls.length, url })
+      log(SOURCE, 'extract-start', { index: i + 1, of: candidates.length, url })
       try {
         const raw = await getPageText(browser, url)
         const $doc = cheerio.load(raw)
         const ogImg = $doc('meta[property="og:image"]').attr('content') ?? ''
-        const authorNames: string[] = []
+        const slugAuthorNames: string[] = []
         $doc('p.author a, .entry-byline a[href*="/author/"]').each((_, el) => {
           const name = $doc(el).text().trim()
-          if (name && !authorNames.includes(name)) authorNames.push(name)
+          if (name && !slugAuthorNames.includes(name)) slugAuthorNames.push(name)
         })
-        const author = authorNames.join(', ')
+        const author = slugAuthorNames.length > 0 ? slugAuthorNames.join(', ') : listingAuthor
         const minimal = buildMinimalDoc(raw)
         log(SOURCE, 'prompt-size', { index: i + 1, chars: minimal.length, hasImage: Boolean(ogImg) })
         const data = await extractArticle(minimal)


### PR DESCRIPTION
  - card is now wrapped in one <Link>, which makes every pixel navigable. cmd-click, middle-click, right-click, status-bar URL preview, and keyboard focus all work as native link behavior
  - dropped from three <Link> elements per card (image, headline, View Details) to one — eliminates redundant anchors that screen readers were announcing three times
  - "View Details →" kept as aria-hidden decorative text inside the card
  - focus-visible on the card shows a visible outline for keyboard users; mouse clicks no longer leave a lingering focus ring