### PR TITLE
Commit:

### DIFF
--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -17,7 +17,7 @@ jobs:
     timeout-minutes: 25
     strategy:
       fail-fast: false
-      max-parallel: 6
+      max-parallel: 2
       matrix:
         source:
           - aljazeera

--- a/scrapers/lib/haiku.ts
+++ b/scrapers/lib/haiku.ts
@@ -45,7 +45,7 @@ const EXTRACT_TOOL = {
 }
 
 const REQUEST_TIMEOUT_MS = 75_000
-const REQUEST_MAX_RETRIES = 1
+const REQUEST_MAX_RETRIES = 3
 
 export async function extractArticle(pageText: string): Promise<ExtractedArticle> {
   const res = await client.messages.create(


### PR DESCRIPTION
  scrapers: stop blowing through haiku rate limit under matrix fan-out

  previous run lost 9/15 courthousenews articles to 429 rate_limit_error. root
  cause: max-parallel: 6 had up to six scrapers hammering haiku at once,
  collectively ~90k output tokens/min vs anthropic's 10k/min cap, and
  maxRetries: 1 meant one unlucky burst killed an extraction instead of riding
  it out

  - drop max-parallel 6 → 2 so peak token rate stays under the cap. wall-clock goes from ~10 min to ~20 min for a full cron, still well under the 25-min per-source budget
  - bump haiku maxRetries 1 → 3 so the sdk's built-in exponential backoff smooths out the bursts that do happen, instead of failing on first 429