### PR TITLE
ui: hide Drop Site News from feed + tabs while scraper is parked

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -27,7 +27,7 @@ export default async function Home({ searchParams }: HomeProps) {
     "Borderland Beat",
     "Courthouse News",
     "Democracy Now!",
-    "Drop Site News",
+    // "Drop Site News", // Disabled: old articles re-surfacing with today's date. See WORK_LOG.md.
     "Jacobin",
     "NPR",
     "The Intercept",

--- a/lib/articles.tsx
+++ b/lib/articles.tsx
@@ -3,6 +3,14 @@ import { Article } from "../types/article";
 
 const PAGE_SIZE = 12;
 
+// Sources whose existing rows should be hidden from the UI even though they
+// remain in the DB. Used to park a scraper while keeping the data for later
+// debugging/restoration. Mirror this in app/page.tsx KNOWN_SOURCES comments
+// so the source tab doesn't show either.
+const HIDDEN_SOURCES = new Set<string>([
+  "Drop Site News", // re-surfacing old articles with today's date — see WORK_LOG.md
+]);
+
 export interface SourceCount {
   source: string;
   count: number;
@@ -32,10 +40,11 @@ export async function getArticles(
       }
     : {};
 
-  const searchScoped = await prisma.article.findMany({
+  const rawSearchScoped = await prisma.article.findMany({
     where: searchWhere,
     orderBy: { date: "desc" },
   });
+  const searchScoped = rawSearchScoped.filter((a) => !HIDDEN_SOURCES.has(a.source));
 
   const sourceCountMap = new Map<string, number>();
   for (const a of searchScoped) {


### PR DESCRIPTION
  - lib/articles.tsx: HIDDEN_SOURCES set filters disabled sources out of feed, source counts, and fallthrough tabs. Rows stay in the DB.
  - app/page.tsx: comment out "Drop Site News" from KNOWN_SOURCES so the tab doesn't render either.

  To re-enable: remove "Drop Site News" from HIDDEN_SOURCES and uncomment
  the KNOWN_SOURCES line.